### PR TITLE
fix: Show customers queue position and estimated wait time 

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -127,3 +127,33 @@ CREATE TRIGGER update_order_item_customizations_modtime
     BEFORE UPDATE ON order_item_customizations
     FOR EACH ROW
     EXECUTE FUNCTION update_modified_column();
+
+-- Returns count of active orders ahead of the given order, bypassing RLS so customers see the global queue.
+CREATE OR REPLACE FUNCTION get_orders_ahead_count(order_id integer)
+RETURNS integer
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT
+    CASE
+      WHEN (SELECT status FROM orders WHERE id = order_id) IN ('completed', 'cancelled') THEN 0
+      ELSE (
+        SELECT COUNT(*)::integer
+        FROM orders
+        WHERE status IN ('pending', 'in_progress')
+        AND created_at < (SELECT created_at FROM orders WHERE id = order_id)
+      )
+    END;
+$$;
+
+-- Returns average order fulfillment time in milliseconds across all completed orders.
+-- SECURITY DEFINER bypasses RLS so all users get the global average, not just their own orders.
+CREATE OR REPLACE FUNCTION get_average_fulfillment_time()
+RETURNS float
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT AVG(EXTRACT(EPOCH FROM (updated_at - created_at)) * 1000)
+  FROM orders
+  WHERE status = 'completed';
+$$;

--- a/src/lib/BaristaView.svelte
+++ b/src/lib/BaristaView.svelte
@@ -11,6 +11,7 @@
     updateMilkAvailability,
     updateItemAvailability,
     updateCustomizationAvailability,
+    getAverageFulfillmentTime,
   } from "./supabase";
   import type { Order } from "../types";
   import Icons from "./Icons.svelte";
@@ -70,21 +71,8 @@
     // Calculate statistics
     completedOrders = orders.filter((order) => order.status === "completed").length;
 
-    const completedOrderTimes = orders
-      .filter((order) => order.status === "completed")
-      .map(
-        (order) =>
-          new Date(order.updated_at).getTime() - new Date(order.created_at).getTime()
-      );
-
-    if (completedOrderTimes.length > 0) {
-      const avgTime =
-        completedOrderTimes.reduce((sum, time) => sum + time, 0) /
-        completedOrderTimes.length;
-      averageFulfillmentTime = formatDuration(avgTime);
-    } else {
-      averageFulfillmentTime = "N/A";
-    }
+    const avgTime = await getAverageFulfillmentTime();
+    averageFulfillmentTime = avgTime !== null ? formatDuration(avgTime) : "N/A";
   }
 
   function formatDuration(ms: number): string {

--- a/src/lib/OrderStatus.svelte
+++ b/src/lib/OrderStatus.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { fade } from "svelte/transition";
-  import { cancelOrder, getOrderDetails, getOrdersAheadCount } from "./supabase";
+  import { cancelOrder, getOrderDetails, getOrdersAheadCount, getAverageFulfillmentTime } from "./supabase";
   import type { OrderDetails } from "../types";
   import Icons from "./Icons.svelte";
 
@@ -13,6 +13,7 @@
   let shouldShowOrderAgain = false;
   let ordersAhead: number | null = null;
   let previousStatus: string | null = null;
+  let avgFulfillmentMs: number | null = null;
 
   const statusMap = {
     pending: "Pending",
@@ -34,6 +35,13 @@
     }
     await updateOrderDetails();
     intervalId = setInterval(updateOrderDetails, 5000);
+    try {
+      avgFulfillmentMs = await getAverageFulfillmentTime();
+      console.log("avgFulfillmentMs", avgFulfillmentMs);
+    } catch (e) {
+      console.error("getAverageFulfillmentTime error", e);
+      avgFulfillmentMs = null;
+    }
   });
 
   onDestroy(() => {
@@ -77,6 +85,12 @@
     }
   }
 
+  function formatDuration(ms: number): string {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}m ${seconds}s`;
+  }
+
   async function handleCancelOrder() {
     if (orderDetails && orderDetails.status === "pending") {
       await cancelOrder(orderId);
@@ -100,11 +114,14 @@
             {statusMap[orderDetails.status]}
           </span>
           {#if ordersAhead !== null && (orderDetails.status === "pending" || orderDetails.status === "in_progress")}
-            <p class="text-sm text-gray-600 mb-2">
+            <p class="text-sm text-gray-600 mb-1">
               {ordersAhead === 0
                 ? "You're up next!"
                 : `${ordersAhead} order${ordersAhead === 1 ? "" : "s"} ahead of you`}
             </p>
+            {#if avgFulfillmentMs !== null}
+              <p class="text-sm text-gray-500 mb-2">Est. wait: ~{formatDuration(avgFulfillmentMs)}</p>
+            {/if}
           {/if}
           <div class="w-48 h-48 flex items-center justify-center">
             {#if orderDetails.status === "pending"}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -264,30 +264,9 @@ export async function updateMilkAvailability(milkId, available) {
 
 // Count how many active orders (pending or in_progress) are ahead of the given order
 export async function getOrdersAheadCount(orderId) {
-  // Fetch the target order's created_at
-  const { data: target, error: targetError } = await supabase
-    .from('orders')
-    .select('id, created_at, status')
-    .eq('id', orderId)
-    .single();
-
-  if (targetError) throw targetError;
-
-  // If the order is completed/cancelled, there are no orders ahead
-  if (target.status === 'completed' || target.status === 'cancelled') {
-    return 0;
-  }
-
-  // Count orders created before this one that are still active
-  const { data: ahead, error: aheadError } = await supabase
-    .from('orders')
-    .select('id')
-    .in('status', ['pending', 'in_progress'])
-    .lt('created_at', target.created_at);
-
-  if (aheadError) throw aheadError;
-
-  return (ahead || []).length;
+  const { data, error } = await supabase.rpc('get_orders_ahead_count', { order_id: orderId })
+  if (error) throw error
+  return data
 }
 
 export async function updateItemAvailability(itemId, available) {
@@ -298,6 +277,12 @@ export async function updateItemAvailability(itemId, available) {
   
   if (error) throw error;
   return data;
+}
+
+export async function getAverageFulfillmentTime() {
+  const { data, error } = await supabase.rpc('get_average_fulfillment_time')
+  if (error) throw error
+  return data
 }
 
 export async function updateCustomizationAvailability(customizationId, available) {


### PR DESCRIPTION
  Fixes a bug where customers can now see how many orders are ahead of theirs and an                                                                                        
  estimated wait time based on historical average fulfillment time.
                                                                                                                                                          
  Before this PR, both values were calculated by querying the `orders` table                                                                                  
  directly, which RLS restricted to the user's own rows — so the queue
  count was always 0 and the average only reflected their own order
  history.